### PR TITLE
[#4] Call "mktemp" properly for Linux as well as MacOS

### DIFF
--- a/autodoc.sh
+++ b/autodoc.sh
@@ -49,7 +49,7 @@ if [[ -z "$AUTODOC_CMD" ]]; then
     exit 1
 fi
 
-VERSION=0020
+VERSION=0021
 
 echo "//======================================\\\\"
 echo "||          AUTODOC v${VERSION}               ||"
@@ -103,7 +103,7 @@ else
 fi
 
 # Create a temp dir
-AUTODOC_TMP=$(mktemp -d -t autodoc)
+AUTODOC_TMP=$(mktemp -d /tmp/autodoc.XXXXXXXX)
 AUTODOC_RESULT=$?
 if [[ ! $AUTODOC_RESULT -eq 0 ]]; then
     echo_error "mktemp returned a non-zero exit status (${AUTODOC_RESULT}), giving up."


### PR DESCRIPTION

This is a hotfix for the last pull request ...  On Linux mktemp needs to called with "XXX" in the template where the random string ought to be inserted ("mktemp -d -t autodoc.XXXXXX").   On MacOS "mktemp -t" does NOT want those "XXX" in the template.

However this alternate form "mktemp -d /tmp/autodoc.XXXXXXXX" works on Mac and Linux equally, so I propose switching to it.